### PR TITLE
fix: Atualizei a ordem de compra para retornar dados que estavam faltando

### DIFF
--- a/lib/domain/entities/purchase_order.dart
+++ b/lib/domain/entities/purchase_order.dart
@@ -1,7 +1,9 @@
 class PurchaseOrder {
   final int id;
+  final String? issuingBody; // órgão emissor
+  final String? commitmentNoteNumber; // número da NE (Nota de Empenho)
   final int? year;
-  final String? orderNumber; // número da NE
+  final String? processNumber; // número do processo
   final int? orderId; // referência ao pedido, se houver
   final int? supplierCompanyId;
   final String? supplierCompanyTitle;
@@ -16,8 +18,10 @@ class PurchaseOrder {
 
   PurchaseOrder({
     required this.id,
+    this.issuingBody,
+    this.commitmentNoteNumber,
     this.year,
-    this.orderNumber,
+    this.processNumber,
     this.orderId,
     this.supplierCompanyId,
     this.supplierCompanyTitle,
@@ -56,11 +60,13 @@ class PurchaseOrder {
 
     return PurchaseOrder(
       id: parseInt(json['id'] ?? json['purchaseOrderId'] ?? json['poId']),
+      issuingBody: json['issuingBody']?.toString(),
+      commitmentNoteNumber: json['commitmentNoteNumber']?.toString(),
       year: json['year'] != null ? parseInt(json['year']) : null,
-      orderNumber: json['orderNumber']?.toString() ?? json['numero']?.toString(),
+      processNumber: json['processNumber']?.toString(),
       orderId: json['orderId'] != null ? parseInt(json['orderId']) : null,
       supplierCompanyId: json['supplierCompanyId'] != null ? parseInt(json['supplierCompanyId']) : null,
-      supplierCompanyTitle: (json['supplierCompanyTitle'] ?? json['supplierTitle'] ?? json['supplier']?['title'])?.toString(),
+      supplierCompanyTitle: (json['supplierCompanyTitle'] ?? json['supplierCompanyName'] ?? json['supplierTitle'] ?? json['supplier']?['title'])?.toString(),
       totalValue: parseDouble(json['totalValue'] ?? json['total']),
       issueDate: parseDate(json['issueDate'] ?? json['emissionDate'] ?? json['issue_date']),
       status: json['status']?.toString() ?? json['situacao']?.toString() ?? '',

--- a/lib/presentation/pages/purchase_order_detail_page.dart
+++ b/lib/presentation/pages/purchase_order_detail_page.dart
@@ -74,7 +74,7 @@ class _PurchaseOrderDetailPageState extends State<PurchaseOrderDetailPage> {
       backgroundColor: Colors.transparent,
       bottomNavigationBar: CustomNavbar(currentIndex: _selectedIndex, onTap: (i) { setState(() => _selectedIndex = i); }),
       body: StandardScreen(
-        title: _po != null ? (_po!.orderNumber != null && _po!.orderNumber!.isNotEmpty ? 'NE ${_po!.orderNumber}' : 'NE #${_po!.id}') : 'Detalhes da Ordem',
+        title: _po != null ? 'OC #${_po!.id}' : 'Detalhes da Ordem',
         child: _isLoading ? const Center(child: CircularProgressIndicator()) : _error != null ? _buildError() : _buildContent(),
       ),
     );
@@ -110,7 +110,13 @@ class _PurchaseOrderDetailPageState extends State<PurchaseOrderDetailPage> {
                 children: [
                   Text('Informações básicas', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
                   const SizedBox(height: 8),
-                  ListTile(title: const Text('Número (NE)'), subtitle: Text(po.orderNumber ?? '—')),
+                  ListTile(
+                    title: const Text('Número da Ordem de Compra (OC)', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                    subtitle: Text('#${po.id}', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: AppColors.infoLight)),
+                  ),
+                  if (po.commitmentNoteNumber != null) ListTile(title: const Text('Nota de Empenho (NE)'), subtitle: Text(po.commitmentNoteNumber!)),
+                  if (po.issuingBody != null) ListTile(title: const Text('Órgão Emissor'), subtitle: Text(po.issuingBody!)),
+                  if (po.processNumber != null) ListTile(title: const Text('Número do Processo'), subtitle: Text(po.processNumber!)),
                   ListTile(title: const Text('Fornecedor'), subtitle: Text(po.supplierCompanyTitle ?? '—')),
                   ListTile(title: const Text('Valor total'), subtitle: Text(po.totalValue != null ? 'R\$ ${po.totalValue!.toStringAsFixed(2)}' : '—')),
                   ListTile(title: const Text('Data de emissão'), subtitle: Text(_formatDate(po.issueDate))),

--- a/lib/presentation/pages/purchase_order_list_page.dart
+++ b/lib/presentation/pages/purchase_order_list_page.dart
@@ -39,8 +39,7 @@ class _PurchaseOrderListPageState extends State<PurchaseOrderListPage> {
   }
 
   String _displayTitle(PurchaseOrder po) {
-    if (po.orderNumber != null && po.orderNumber!.isNotEmpty) return 'NE ${po.orderNumber}';
-    return 'NE #${po.id}';
+    return 'OC #${po.id}';
   }
 
   Color _statusColor(String status) {


### PR DESCRIPTION
Added 'issuingBody', 'commitmentNoteNumber', and 'processNumber' fields to PurchaseOrder entity. Updated detail and list pages to display new fields and changed labels from NE (Nota de Empenho) to OC (Ordem de Compra) for consistency.